### PR TITLE
fix for installation on ubuntu LTS if clamav updates

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,8 @@ when "debian"
     when "10.04"
       default["clamav"]["version"] = "#{base_ver}+dfsg-1ubuntu0.11.04.1~" +
         "10.04.1~ppa1"
+    when "12.04"
+      default["clamav"]["version"] = nil
     else
       default["clamav"]["version"] = "#{base_ver}+dfsg-1ubuntu0." +
         "#{node["platform_version"]}.1"


### PR DESCRIPTION
old version was not avalible on the repo.

This breaks the chef run.

So, dspam was broken at some point and not re-setup by chef
So, postfix didn't work

So, no Mail outgoing or incoming for a few hours without recognizing in frontend.

So here is a fix for specifically Ubuntu LTS 12.04
