### PR TITLE
less restrictive dependencies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ description       "Installs/configures clamav"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "0.2.0"
 
-depends           "logrotate", "= 1.0.2"
+depends           "logrotate", ">= 1.0.2"
 depends           "yum", "= 2.1.0"
-depends           "apt", "= 1.8.0"
+depends           "apt", ">= 1.8.0"
 
 supports          "ubuntu"
 supports          "debian"


### PR DESCRIPTION
Dependencies are already outdated.

I do not think, there will be large api change on these cookbooks.

Maybe we like to add a major version number restriction like

depends           "apt", ">= 1.8.0" and "< 2.0.0"
or
depends           "apt", ">= 1.8.0" and "<1.9.0"

Is this even possible?
