### PR TITLE
Expand deps to major versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,9 @@ description       "Installs/configures clamav"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "0.2.0"
 
-depends           "logrotate", "= 1.0.2"
-depends           "yum", "= 2.1.0"
-depends           "apt", "= 1.8.0"
+depends           "logrotate", "~> 1.0"
+depends           "yum", "~> 2.1"
+depends           "apt", "~> 1.8"
 
 supports          "ubuntu"
 supports          "debian"


### PR DESCRIPTION
Per the [Cookbook Versioning Policy](https://github.com/chef-community/cvp), only major version changes should break backwards compatibility.
