### PR TITLE
Removes duplicate run of freshclam.

### DIFF
--- a/recipes/freshclam.rb
+++ b/recipes/freshclam.rb
@@ -39,10 +39,11 @@ template "#{node["clamav"]["conf_dir"]}/freshclam.conf" do
     :notify_clamd => notify,
     :bytecode => node["clamav"]["bytecode"]
   )
-  notifies :run, "execute[freshclam]", :immediately
   if node["clamav"]["freshclam"]["enabled"]
     notifies :restart, "service[#{node["clamav"]["freshclam"]["service"]}]",
       :delayed
+  else
+    notifies :run, "execute[freshclam]", :immediately
   end
 end
 


### PR DESCRIPTION
If the freshclam service is enabled, freshclam will have already begun
it's initial definition download. Forcing an execution of freshclam at
this point can collide with an already running instance.

Let's move this forced execution to the case where the user doesn't want
freshclam service enabled, but we need to ensure the virus definitions
are updated at least once.
