### PR TITLE
Update to use v3 of yum cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,8 @@ long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version           "0.4.2"
 
 depends           "logrotate", "~> 1.0"
-depends           "yum", "~> 2.1"
+depends           "yum", "~> 3.0"
+depends           "yum-epel", "~> 0.7"
 depends           "apt", "~> 2.1"
 
 supports          "ubuntu"

--- a/recipes/install_rpm.rb
+++ b/recipes/install_rpm.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "yum::epel"
+include_recipe "yum-epel"
 
 service node["clamav"]["clamd"]["service"]
 service node["clamav"]["freshclam"]["service"]


### PR DESCRIPTION
This makes very simple changes to accommodate the new way EPEL is handled in v3 of the yum cookbook. 

I know it works on my system (CentOS 6.4) but I'm no chef expert so I've been unable to run the full suite of tests.
