### PR TITLE
Added service files for RHEL family 7 upwards

### DIFF
--- a/recipes/install_rpm.rb
+++ b/recipes/install_rpm.rb
@@ -60,26 +60,48 @@ yum_package 'clamav-devel' do
   only_if { node['clamav']['dev_package'] }
 end
 
-template "/etc/init.d/#{node['clamav']['clamd']['service']}" do
-  source 'clamd.init.rhel.erb'
-  mode '0755'
-  action :create
-  variables(
-    clamd_conf: "#{node['clamav']['conf_dir']}/clamd.conf",
-    clamd_pid: node['clamav']['clamd']['pid_file'],
-    clamd_bin_dir: '/usr/sbin'
-  )
-end
-
-template "/etc/init.d/#{node['clamav']['freshclam']['service']}" do
-  source 'freshclam.init.rhel.erb'
-  mode '0755'
-  action :create
-  variables(
-    freshclam_conf: "#{node['clamav']['conf_dir']}/freshclam.conf",
-    freshclam_pid: node['clamav']['freshclam']['pid_file'],
-    freshclam_bin_dir: '/usr/bin'
-  )
+if platform_family?('rhel') && node['platform_version'].split('.').first.to_i == 7
+  template "/etc/systemd/system/#{node['clamav']['clamd']['service']}.service" do
+    source 'clamd.service.erb'
+    mode '0755'
+    action :create
+    variables(
+      clamd_conf: "#{node['clamav']['conf_dir']}/clamd.conf",
+      clamd_pid: node['clamav']['clamd']['pid_file'],
+      clamd_bin_dir: '/usr/sbin'
+    )
+  end
+  template "/etc/systemd/system/#{node['clamav']['freshclam']['service']}.service" do
+    source 'freshclam.service.erb'
+    mode '0755'
+    action :create
+    variables(
+      freshclam_conf: "#{node['clamav']['conf_dir']}/freshclam.conf",
+      freshclam_pid: node['clamav']['freshclam']['pid_file'],
+      freshclam_bin_dir: '/usr/bin'
+    )
+  end
+else
+  template "/etc/init.d/#{node['clamav']['clamd']['service']}" do
+    source 'clamd.init.rhel.erb'
+    mode '0755'
+    action :create
+    variables(
+      clamd_conf: "#{node['clamav']['conf_dir']}/clamd.conf",
+      clamd_pid: node['clamav']['clamd']['pid_file'],
+      clamd_bin_dir: '/usr/sbin'
+    )
+  end
+  template "/etc/init.d/#{node['clamav']['freshclam']['service']}" do
+    source 'freshclam.init.rhel.erb'
+    mode '0755'
+    action :create
+    variables(
+      freshclam_conf: "#{node['clamav']['conf_dir']}/freshclam.conf",
+      freshclam_pid: node['clamav']['freshclam']['pid_file'],
+      freshclam_bin_dir: '/usr/bin'
+    )
+  end
 end
 
 template '/etc/sysconfig/freshclam' do

--- a/templates/default/clamd.service.erb
+++ b/templates/default/clamd.service.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=clamav daemon
+
+[Service]
+Type=forking
+PIDFile=<%= @clamd_pid %>
+ExecStart=<%= @clamd_bin_dir %>/clamd -c <%= @clamd_conf %>
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/default/freshclam.service.erb
+++ b/templates/default/freshclam.service.erb
@@ -1,0 +1,10 @@
+[Unit]
+Description=freshclam daemon
+
+[Service]
+Type=forking
+PIDFile=<%= @freshclam_pid %>
+ExecStart=<%= @freshclam_bin_dir %>/freshclam -d -p <%= @freshclam_pid %>
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds systemd scripts for Rhel7 family. I have run kitchen test all-options-enabled-centos-70 and 66, but 511 fails due to a separate issue:

Error executing action `create` on resource 'template[/etc/cron.d/clamav_minimal_scan]'
Chef::Exceptions::EnclosingDirectoryDoesNotExist
           ------------------------------------------------
           Parent directory /etc/cron.d does not exist.