### PR TITLE
Switch freshclam execution to delayed to avoid long chef_run

### DIFF
--- a/recipes/freshclam.rb
+++ b/recipes/freshclam.rb
@@ -54,7 +54,7 @@ template "#{node['clamav']['conf_dir']}/freshclam.conf" do
              :delayed
   end
   if !node['clamav']['freshclam']['enabled'] || platform_family == 'debian'
-    notifies :run, 'execute[freshclam]', :immediately
+    notifies :run, 'execute[freshclam]', :delayed
   end
 end
 


### PR DESCRIPTION
The freshclam execution is switched to delayed so the chef_run can keep running.

This is to solve this issue : 
https://github.com/RoboticCheese/clamav-chef/issues/52