### PR TITLE
remove the immediate apt-get update on every run

### DIFF
--- a/recipes/install_deb.rb
+++ b/recipes/install_deb.rb
@@ -28,7 +28,6 @@ apt_repository 'clamav-repo' do
   keyserver 'keyserver.ubuntu.com'
   key '5ADC2037'
   only_if { node['platform'] == 'ubuntu' }
-  notifies :run, 'execute[apt-get update]', :immediately
 end
 
 package 'clamav' do


### PR DESCRIPTION
the chef apt_repository lwrp will do this automatically if the repository is added