### PR TITLE
Remove the forced execution of freshclam on ubuntu/debian

### DIFF
--- a/recipes/freshclam.rb
+++ b/recipes/freshclam.rb
@@ -52,8 +52,7 @@ template "#{node['clamav']['conf_dir']}/freshclam.conf" do
   if node['clamav']['freshclam']['enabled']
     notifies :restart, "service[#{node['clamav']['freshclam']['service']}]",
              :delayed
-  end
-  if !node['clamav']['freshclam']['enabled'] || platform_family == 'debian'
+  else
     notifies :run, 'execute[freshclam]', :delayed
   end
 end

--- a/recipes/install_deb.rb
+++ b/recipes/install_deb.rb
@@ -21,16 +21,6 @@
 include_recipe 'apt'
 include_recipe "#{cookbook_name}::services"
 
-apt_repository 'clamav-repo' do
-  uri 'http://ppa.launchpad.net/ubuntu-clamav/ppa/ubuntu'
-  distribution node['lsb']['codename']
-  components ['main']
-  keyserver 'keyserver.ubuntu.com'
-  key '5ADC2037'
-  only_if { node['platform'] == 'ubuntu' }
-  notifies :run, 'execute[apt-get update]', :immediately
-end
-
 package 'clamav' do
   action :install
   version node['clamav']['version'] if node['clamav']['version']


### PR DESCRIPTION
Remove the forced execution of freshclam on ubuntu (or debian based distros). 
It will be executed only if the attribute is set.

Fix the issue : https://github.com/RoboticCheese/clamav-chef/issues/52
