### PR TITLE
Give each config a base default

### DIFF
--- a/libraries/helpers_defaults.rb
+++ b/libraries/helpers_defaults.rb
@@ -50,6 +50,24 @@ module ClamavCookbook
       end
 
       #
+      # The bare minimum freshclam.conf required for it to function.
+      #
+      # @return [Hash] a barebones freshclam config
+      #
+      def freshclam_config
+        { database_mirror: %w(db.local.clamav.net database.clamav.net) }
+      end
+
+      #
+      # The bare minimum clamd.conf required for it to function.
+      #
+      # @return [Hash] a barebones clamd config
+      #
+      def clamd_config
+        {}
+      end
+
+      #
       # The directory containing ClamAV's virus definition files.
       #
       # @return [String] the data directory

--- a/libraries/provider_clamav_config.rb
+++ b/libraries/provider_clamav_config.rb
@@ -56,7 +56,9 @@ class Chef
         file path do
           owner clamav_user
           group clamav_group
-          content ClamavCookbook::Helpers::Config.new(new_resource.config).to_s
+          content ClamavCookbook::Helpers::Config.new(
+            send("#{new_resource.name}_config").merge(new_resource.config.to_h)
+          ).to_s
         end
       end
 

--- a/spec/libraries/helpers_defaults_spec.rb
+++ b/spec/libraries/helpers_defaults_spec.rb
@@ -53,6 +53,46 @@ describe ClamavCookbook::Helpers::Defaults do
     end
   end
 
+  describe '#freshclam_config' do
+    context 'Ubuntu 14.04' do
+      let(:platform) { { platform: 'ubuntu', version: '14.04' } }
+
+      it 'returns the correct config' do
+        expect(test_obj.freshclam_config).to eq(
+          database_mirror: %w(db.local.clamav.net database.clamav.net)
+        )
+      end
+    end
+
+    context 'Debian 8.2' do
+      let(:platform) { { platform: 'debian', version: '8.2' } }
+
+      it 'returns the correct config' do
+        expect(test_obj.freshclam_config).to eq(
+          database_mirror: %w(db.local.clamav.net database.clamav.net)
+        )
+      end
+    end
+  end
+
+  describe '#clamd_config' do
+    context 'Ubuntu 14.04' do
+      let(:platform) { { platform: 'ubuntu', version: '14.04' } }
+
+      it 'returns the correct config' do
+        expect(test_obj.clamd_config).to eq({})
+      end
+    end
+
+    context 'Debian 8.2' do
+      let(:platform) { { platform: 'debian', version: '8.2' } }
+
+      it 'returns the correct config' do
+        expect(test_obj.clamd_config).to eq({})
+      end
+    end
+  end
+
   describe '#clamav_data_dir' do
     context 'Ubuntu 14.04' do
       let(:platform) { { platform: 'ubuntu', version: '14.04' } }

--- a/spec/resources/clamav_config/ubuntu/14_04_spec.rb
+++ b/spec/resources/clamav_config/ubuntu/14_04_spec.rb
@@ -56,6 +56,8 @@ describe 'resource_clamav_config::ubuntu::14_04' do
           # This file generated automatically by Chef. #
           # Any local changes will be overwritten.     #
           ##############################################
+          DatabaseMirror db.local.clamav.net
+          DatabaseMirror database.clamav.net
         EOH
         expect(chef_run).to create_file('/etc/clamav/freshclam.conf')
           .with(owner: 'clamav', group: 'clamav', content: expected)


### PR DESCRIPTION
Freshclam won't run without a DatabaseMirror, so let's give each service
a set of barebones defaults that the resource's config is then merged
into.