### PR TITLE
Give clamd configs a default socket file

### DIFF
--- a/libraries/helpers_defaults.rb
+++ b/libraries/helpers_defaults.rb
@@ -64,7 +64,7 @@ module ClamavCookbook
       # @return [Hash] a barebones clamd config
       #
       def clamd_config
-        {}
+        { local_socket: '/var/run/clamav/clamd.sock' }
       end
 
       #

--- a/spec/libraries/helpers_defaults_spec.rb
+++ b/spec/libraries/helpers_defaults_spec.rb
@@ -80,7 +80,9 @@ describe ClamavCookbook::Helpers::Defaults do
       let(:platform) { { platform: 'ubuntu', version: '14.04' } }
 
       it 'returns the correct config' do
-        expect(test_obj.clamd_config).to eq({})
+        expect(test_obj.clamd_config).to eq(
+          local_socket: '/var/run/clamav/clamd.sock'
+        )
       end
     end
 
@@ -88,7 +90,9 @@ describe ClamavCookbook::Helpers::Defaults do
       let(:platform) { { platform: 'debian', version: '8.2' } }
 
       it 'returns the correct config' do
-        expect(test_obj.clamd_config).to eq({})
+        expect(test_obj.clamd_config).to eq(
+          local_socket: '/var/run/clamav/clamd.sock'
+        )
       end
     end
   end

--- a/spec/resources/clamav_config/ubuntu/14_04_spec.rb
+++ b/spec/resources/clamav_config/ubuntu/14_04_spec.rb
@@ -38,6 +38,7 @@ describe 'resource_clamav_config::ubuntu::14_04' do
           # This file generated automatically by Chef. #
           # Any local changes will be overwritten.     #
           ##############################################
+          LocalSocket /var/run/clamav/clamd.sock
         EOH
         expect(chef_run).to create_file('/etc/clamav/clamd.conf')
           .with(owner: 'clamav', group: 'clamav', content: expected)


### PR DESCRIPTION
To start at all, the clam daemon requires a minimum of a socket type.