### PR TITLE
Adding a random delay on the cron scan

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default['clamav']['group'] = 'clamav'
 default['clamav']['allow_supplementary_groups'] = 'no'
 default['clamav']['bytecode'] = 'yes'
 
+default['clamav']['scan']['random_delay'] = 15
 default['clamav']['scan']['script']['path'] = '/usr/local/bin/clamav-scan.sh'
 default['clamav']['scan']['script']['enable'] = false
 default['clamav']['scan']['minimal']['minute'] = '42'

--- a/recipes/clamav_scan.rb
+++ b/recipes/clamav_scan.rb
@@ -29,6 +29,7 @@ end
 script_path = node['clamav']['scan']['script']['path']
 min_dirs = node['clamav']['scan']['minimal']['dirs']
 full_dirs = node['clamav']['scan']['full']['dirs']
+cron_env_vars = {"RANDOM_DELAY" => "#{node['clamav']['scan']['random_delay']}"}
 
 cron_d 'clamav_minimal_scan' do
   minute node['clamav']['scan']['minimal']['minute']
@@ -37,6 +38,7 @@ cron_d 'clamav_minimal_scan' do
   user node['clamav']['scan']['user']
   mailto node['clamav']['scan']['mailto']
   command "#{script_path} #{min_dirs}"
+  environment cron_env_vars
   only_if { node['clamav']['scan']['minimal']['enable'] }
 end
 
@@ -47,5 +49,6 @@ cron_d 'clamav_full_scan' do
   user node['clamav']['scan']['user']
   mailto node['clamav']['scan']['mailto']
   command "#{script_path} #{full_dirs}"
+  environment cron_env_vars
   only_if { node['clamav']['scan']['full']['enable'] }
 end


### PR DESCRIPTION
When deploying this into a virtual environment, I didn't want all our nodes to start scanning at the same time.  By adding this random delay into the cron it can spread out the start times, preventing any brown outs to VM host