### PR TITLE
bumps apt dependency to ~> 3.0 requiring chef 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ are accessible as attributes.
 Requirements
 ============
 * A RHEL/CentOS/Scientific, Debian/Ubuntu, or compatible OS
+* Chef 11+
 
 Attributes
 ==========

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,8 @@ maintainer_email  'j@p4nt5.com'
 license           'Apache v2.0'
 description       'Installs/configures ClamAV'
 long_description  'Installs/configures ClamAV'
+source_url        'https://github.com/RoboticCheese/clamav-chef'
+issues_url        'https://github.com/RoboticCheese/clamav-chef/issues'
 version           '1.3.1'
 
 depends           'logrotate', '~> 1.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,7 @@ version           '1.3.1'
 depends           'logrotate', '~> 1.0'
 depends           'yum', '~> 3.0'
 depends           'yum-epel', '~> 0.2'
-depends           'apt', '~> 2.1'
+depends           'apt', '~> 3.0'
 # Note that a breaking bug was introduced in 1.3.10 and fixed in 1.3.12, but
 # we really don't want a ">=" cookbook dep situation here
 depends           'cron', '~> 1.2'


### PR DESCRIPTION
time to bump apt cookbook version, please. v3.0.0 removed compatibility for chef 10, but still supports chef 11+. Apt v4.0.0 is chef 12+, this PR only asks for ~> 3.0, maintaining Chef 11+

@RoboticCheese please review, merge, and version and release (I imagine as 2.0.0). many thanks