### PR TITLE
Upgrade to centos7 with poise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
   only:
     - master
 
-sudo: required
+sudo: false
 
 services:
   - docker

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,7 @@ depends           'logrotate', '~> 1.0'
 depends           'yum', '~> 3.0'
 depends           'yum-epel', '~> 0.2'
 depends           'apt', '~> 2.1'
+depends           'poise-service'
 # Note that a breaking bug was introduced in 1.3.10 and fixed in 1.3.12, but
 # we really don't want a ">=" cookbook dep situation here
 depends           'cron', '~> 1.2'

--- a/recipes/install_rpm.rb
+++ b/recipes/install_rpm.rb
@@ -60,28 +60,6 @@ yum_package 'clamav-devel' do
   only_if { node['clamav']['dev_package'] }
 end
 
-template "/etc/init.d/#{node['clamav']['clamd']['service']}" do
-  source 'clamd.init.rhel.erb'
-  mode '0755'
-  action :create
-  variables(
-    clamd_conf: "#{node['clamav']['conf_dir']}/clamd.conf",
-    clamd_pid: node['clamav']['clamd']['pid_file'],
-    clamd_bin_dir: '/usr/sbin'
-  )
-end
-
-template "/etc/init.d/#{node['clamav']['freshclam']['service']}" do
-  source 'freshclam.init.rhel.erb'
-  mode '0755'
-  action :create
-  variables(
-    freshclam_conf: "#{node['clamav']['conf_dir']}/freshclam.conf",
-    freshclam_pid: node['clamav']['freshclam']['pid_file'],
-    freshclam_bin_dir: '/usr/bin'
-  )
-end
-
 template '/etc/sysconfig/freshclam' do
   owner 'root'
   group 'root'

--- a/recipes/services.rb
+++ b/recipes/services.rb
@@ -1,7 +1,7 @@
 # Encoding: UTF-8
 #
 # Cookbook Name:: clamav
-# Recipe:: services
+# Recipe:: poise_services
 #
 # Copyright 2012-2016, Jonathan Hartman
 #
@@ -20,34 +20,34 @@
 
 c_service = node['clamav']['clamd']['service']
 c_enabled = node['clamav']['clamd']['enabled']
-service c_service do
-  supports status: true, restart: true
+poise_service c_service do
+  command "/usr/sbin/clamd -c #{node['clamav']['conf_dir']}/clamd.conf"
   action :nothing
 end
 
 f_service = node['clamav']['freshclam']['service']
 f_enabled = node['clamav']['freshclam']['enabled']
-service f_service do
-  supports status: true, restart: true
+poise_service f_service do
+  command "/usr/bin/freshclam -d --config-file=#{node['clamav']['conf_dir']}/freshclam.conf}"
   action :nothing
 end
 
-ruby_block 'dummy service notification block' do
+ruby_block 'dummy poise_service notification block' do
   block do
-    Chef::Log.info('Dispatching service notifications...')
+    Chef::Log.info('Dispatching poise_service notifications...')
   end
   if c_enabled
-    notifies :enable, "service[#{c_service}]"
-    notifies :start, "service[#{c_service}]"
+    notifies :enable, "poise_service[#{c_service}]"
+    notifies :start, "poise_service[#{c_service}]"
   else
-    notifies :stop, "service[#{c_service}]"
-    notifies :disable, "service[#{c_service}]"
+    notifies :stop, "poise_service[#{c_service}]"
+    notifies :disable, "poise_service[#{c_service}]"
   end
   if f_enabled
-    notifies :enable, "service[#{f_service}]"
-    notifies :start, "service[#{f_service}]"
+    notifies :enable, "poise_service[#{f_service}]"
+    notifies :start, "poise_service[#{f_service}]"
   else
-    notifies :stop, "service[#{f_service}]"
-    notifies :disable, "service[#{f_service}]"
+    notifies :stop, "poise_service[#{f_service}]"
+    notifies :disable, "poise_service[#{f_service}]"
   end
 end

--- a/recipes/services.rb
+++ b/recipes/services.rb
@@ -28,7 +28,7 @@ end
 f_service = node['clamav']['freshclam']['service']
 f_enabled = node['clamav']['freshclam']['enabled']
 poise_service f_service do
-  command "/usr/bin/freshclam -d --config-file=#{node['clamav']['conf_dir']}/freshclam.conf}"
+  command "/usr/bin/freshclam -d --config-file=#{node['clamav']['conf_dir']}/freshclam.conf"
   action :nothing
 end
 


### PR DESCRIPTION
Upgraded to use poise service (which simplified the cookbook but broke compatibility with chef 11) and upgraded to use the new travis infrastructure. 
