### PR TITLE
Implemented private repo feature in freshclam

### DIFF
--- a/attributes/freshclam.rb
+++ b/attributes/freshclam.rb
@@ -70,3 +70,7 @@ default['clamav']['freshclam']['extra_databases'] = []
 # Other
 default['clamav']['freshclam']['rhel_cron_disable'] = true
 default['clamav']['freshclam']['skip_initial_run'] = false
+
+#Private Mirror
+default['clamav']['freshclam']['use_private_mirror'] = false
+default['clamav']['freshclam']['private_database_mirrors'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email  'j@p4nt5.com'
 license           'Apache v2.0'
 description       'Installs/configures ClamAV'
 long_description  'Installs/configures ClamAV'
-version           '1.3.1'
+version           '1.3.2'
 
 depends           'logrotate', '~> 1.0'
 depends           'yum', '~> 3.0'

--- a/templates/default/freshclam.conf.erb
+++ b/templates/default/freshclam.conf.erb
@@ -73,8 +73,15 @@
 # are doing.
 #DatabaseMirror db.local.clamav.net
 #DatabaseMirror db.local.clamav.net
-<% @freshclam["database_mirrors"].each do |dbm| %>
-<%= "DatabaseMirror #{dbm}" %>
+
+<% if node['clamav']['freshclam']['use_private_mirror'] %>
+	<% @freshclam["private_database_mirrors"].each do |dbm| %>
+	<%= "PrivateMirror #{dbm}" %>
+	<% end %>
+<% else %>
+	<% @freshclam["database_mirrors"].each do |dbm| %>
+	<%= "DatabaseMirror #{dbm}" %>
+	<% end %>
 <% end %>
 
 # How many attempts to make before giving up.


### PR DESCRIPTION
Using freshclam's Private repo feature

# This option allows you to easily point freshclam to private mirrors.
# If PrivateMirror is set, freshclam does not attempt to use DNS
# to determine whether its databases are out-of-date, instead it will
# use the If-Modified-Since request or directly check the headers of the
# remote database files. For each database, freshclam first attempts
# to download the CLD file. If that fails, it tries to download the
# CVD file. This option overrides DatabaseMirror, DNSDatabaseInfo
# and ScriptedUpdates. It can be used multiple times to provide
# fall-back mirrors. 