### PR TITLE
Remove upper limit on dependent cookbooks and resolve all test errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'test/**/*.rb'
+    - 'spec/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 ClamAV Cookbook CHANGELOG
 =========================
 
+v1.3.1 (2017-02-02)
+-------------------
+* Open dependencies to allow newer cookbooks to be pulled in
+* Upodated rubocop settings and fixed any robocop errors
+* Fixed all Foodcritic issues
+* Fixed all spec tests that were failing
+* Added Ubunto v14 and v16 to spec tests
+
 v1.3.0 (2016-02-05)
 -------------------
 * Remove the additional Ubuntu repo; it was shut down 2016/01/30

--- a/Gemfile
+++ b/Gemfile
@@ -3,23 +3,23 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'rake'
-  gem 'rubocop'
-  gem 'foodcritic', '~> 6.0'
-  gem 'rspec'
   gem 'chefspec'
-  gem 'simplecov'
-  gem 'simplecov-console'
   gem 'coveralls'
   gem 'fauxhai'
-  gem 'test-kitchen'
-  gem 'kitchen-vagrant'
+  gem 'foodcritic', '~> 6.0'
   gem 'kitchen-docker'
+  gem 'kitchen-vagrant'
+  gem 'rake'
+  gem 'rspec'
+  gem 'rubocop'
+  gem 'simplecov'
+  gem 'simplecov-console'
+  gem 'test-kitchen'
 end
 
 group :integration do
-  gem 'serverspec'
   gem 'cucumber'
+  gem 'serverspec'
 end
 
 group :deploy do
@@ -27,6 +27,6 @@ group :deploy do
 end
 
 group :production do
-  gem 'chef', '>= 11'
   gem 'berkshelf'
+  gem 'chef', '>= 11'
 end

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Whether to install the appropriate ClamAV development package
 
     default["clamav"]["clamd"]["log_file"] = "/var/log/clamav/clamd.log"
     default["clamav"]["clamd"]["logrotate_frequency"] = "daily"
-    default["clamav"]["clamd"]["logrotate_rotations"] = 7 
+    default["clamav"]["clamd"]["logrotate_rotations"] = 7
     default["clamav"]["clamd"]["log_file_unlock"] = "no"
     default["clamav"]["clamd"]["log_file_max_size"] = "1M"
     default["clamav"]["clamd"]["log_time"] = "no"
     default["clamav"]["clamd"]["log_clean"] = "no"
     default["clamav"]["clamd"]["log_syslog"] = "no"
-    default["clamav"]["clamd"]["log_facility"] = nil 
+    default["clamav"]["clamd"]["log_facility"] = nil
     default["clamav"]["clamd"]["log_verbose"] = "no"
     default["clamav"]["freshclam"]["update_log_file"] = "/var/log/clamav/freshclam.log"
     default["clamav"]["freshclam"]["logrotate_frequency"] = "daily"
@@ -52,7 +52,7 @@ Whether to install the appropriate ClamAV development package
     default["clamav"]["freshclam"]["log_time"] = "no"
     default["clamav"]["freshclam"]["log_verbose"] = "no"
     default["clamav"]["freshclam"]["log_syslog"] = "no"
-    default["clamav"]["freshclam"]["log_facility"] = nil 
+    default["clamav"]["freshclam"]["log_facility"] = nil
 
 Log file/syslog facility logging options
 
@@ -100,16 +100,17 @@ Contributing
 1. Fork it
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Add appropriate unit and/or integration tests
-4. Ensure all tests pass (`rake`)
-5. Commit your changes (`git commit -am 'Add some feature'`)
-6. Push to the branch (`git push origin my-new-feature`)
-7. Create new Pull Request
+4. Run `berks install` or `berks update`
+5. Ensure all tests pass (`rake`)
+6. Commit your changes (`git commit -am 'Add some feature'`)
+7. Push to the branch (`git push origin my-new-feature`)
+8. Create new Pull Request
 
 License & Authors
 =================
 - Author: Jonathan Hartman <j@p4nt5.com>
 
-Copyright 2012-2016, Jonathan Hartman
+Copyright 2012-2017, Jonathan Hartman
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,15 +6,14 @@ maintainer_email  'j@p4nt5.com'
 license           'Apache v2.0'
 description       'Installs/configures ClamAV'
 long_description  'Installs/configures ClamAV'
-version           '1.3.0'
+source_url        'https://github.com/RoboticCheese/clamav-chef/issues'
+issues_url        'https://github.com/RoboticCheese/clamav-chef/issues'
+version           '1.3.1'
 
-depends           'logrotate', '~> 1.0'
-depends           'yum', '~> 3.0'
-depends           'yum-epel', '~> 0.2'
-depends           'apt', '~> 2.1'
-# Note that a breaking bug was introduced in 1.3.10 and fixed in 1.3.12, but
-# we really don't want a ">=" cookbook dep situation here
-depends           'cron', '~> 1.2'
+depends           'apt'
+depends           'logrotate', '>= 1.0'
+depends           'yum', '>= 3.0'
+depends           'yum-epel', '>= 0.2'
 
 supports          'ubuntu'
 supports          'debian'

--- a/spec/recipes/clamav_scan_spec.rb
+++ b/spec/recipes/clamav_scan_spec.rb
@@ -7,7 +7,7 @@ describe 'clamav::clamav_scan' do
   let(:attributes) { {} }
   let(:runner) do
     ChefSpec::SoloRunner.new do |node|
-      attributes.each { |k, v| node.set[k] = v }
+      attributes.each { |k, v| node.override[k] = v }
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }

--- a/spec/recipes/clamd_spec.rb
+++ b/spec/recipes/clamd_spec.rb
@@ -9,7 +9,7 @@ describe 'clamav::clamd' do
   let(:attributes) { {} }
   let(:runner) do
     ChefSpec::SoloRunner.new(platform) do |node|
-      attributes.each { |k, v| node.set[k] = v }
+      attributes.each { |k, v| node.override[k] = v }
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }
@@ -136,34 +136,42 @@ describe 'clamav::clamd' do
   {
     Ubuntu: {
       platform: 'ubuntu',
-      version: '12.04',
+      versions: %w(12.04 14.10 16.04),
       conf: '/etc/clamav/clamd.conf',
       service: 'service[clamav-daemon]'
     },
     CentOS: {
       platform: 'centos',
-      version: '6.4',
+      versions: %w(6.4),
       conf: '/etc/clamd.conf',
       service: 'service[clamd]'
     }
   }.each do |k, v|
-    context "a #{k} node" do
-      let(:platform) { { platform: v[:platform], version: v[:version] } }
-      let(:conf) { v[:conf] }
-      let(:service) { v[:service] }
-
-      context 'an entirely default node' do
-        it_behaves_like 'any node'
-        it_behaves_like 'a node with all default attributes'
-        it_behaves_like 'a node with the clamd service disabled'
+    v[:versions].each do |version|
+      before do
+        Fauxhai.mock(platform: v[:platform], version: version) do |node|
+          node['languages']['ruby']['version'] = '2.3.1'
+        end
       end
 
-      context 'a node with the clamd service enabled' do
-        let(:attributes) { { clamav: { clamd: { enabled: true } } } }
+      context "a #{k} v.#{version} node" do
+        let(:platform) { { platform: v[:platform], version: version } }
+        let(:conf) { v[:conf] }
+        let(:service) { v[:service] }
 
-        it_behaves_like 'any node'
-        it_behaves_like 'a node with all default attributes'
-        it_behaves_like 'a node with the clamd service enabled'
+        context 'an entirely default node' do
+          it_behaves_like 'any node'
+          it_behaves_like 'a node with all default attributes'
+          it_behaves_like 'a node with the clamd service disabled'
+        end
+
+        context 'a node with the clamd service enabled' do
+          let(:attributes) { { clamav: { clamd: { enabled: true } } } }
+
+          it_behaves_like 'any node'
+          it_behaves_like 'a node with all default attributes'
+          it_behaves_like 'a node with the clamd service enabled'
+        end
       end
     end
   end

--- a/spec/recipes/install_deb_spec.rb
+++ b/spec/recipes/install_deb_spec.rb
@@ -10,7 +10,7 @@ describe 'clamav::install_deb' do
   let(:platform) { { platform: 'ubuntu', version: '12.04' } }
   let(:runner) do
     ChefSpec::SoloRunner.new(platform) do |node|
-      attributes.each { |k, v| node.set[k] = v }
+      attributes.each { |k, v| node.override[k] = v }
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }

--- a/spec/recipes/install_rpm_spec.rb
+++ b/spec/recipes/install_rpm_spec.rb
@@ -12,7 +12,7 @@ describe 'clamav::install_rpm' do
   let(:platform) { { platform: 'centos', version: '6.4' } }
   let(:runner) do
     ChefSpec::SoloRunner.new(platform) do |node|
-      attributes.each { |k, v| node.set[k] = v }
+      attributes.each { |k, v| node.override[k] = v }
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }

--- a/spec/recipes/logging_spec.rb
+++ b/spec/recipes/logging_spec.rb
@@ -9,7 +9,7 @@ describe 'clamav::logging' do
   let(:attributes) { {} }
   let(:runner) do
     ChefSpec::SoloRunner.new do |node|
-      attributes.each { |k, v| node.set[k] = v }
+      attributes.each { |k, v| node.override[k] = v }
     end
   end
   let(:chef_run) { runner.converge(described_recipe) }
@@ -60,7 +60,7 @@ describe 'clamav::logging' do
       )
     end
 
-    context 'a node set to log to syslog instead of files' do
+    context 'a node.override to log to syslog instead of files' do
       let(:attributes) do
         {
           clamav: {

--- a/spec/recipes/users_spec.rb
+++ b/spec/recipes/users_spec.rb
@@ -8,7 +8,7 @@ describe 'clamav::users' do
   let(:attributes) { {} }
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
-      attributes.each { |k, v| node.set[k] = v }
+      attributes.each { |k, v| node.override[k] = v }
     end.converge(described_recipe)
   end
 

--- a/spec/support/resources/logrotate_app.rb
+++ b/spec/support/resources/logrotate_app.rb
@@ -28,7 +28,7 @@ class Chef
       end
 
       def rotate(arg = nil)
-        set_or_return(:rotate, arg, kind_of: Fixnum)
+        set_or_return(:rotate, arg, kind_of: Integer)
       end
 
       def create(arg = nil)

--- a/test/integration/all_options_enabled/cucumber/step_definitions/clamav_steps.rb
+++ b/test/integration/all_options_enabled/cucumber/step_definitions/clamav_steps.rb
@@ -16,7 +16,7 @@ When(/^I scan a (\w+) file via clamd$/) do |file_type|
   end
   @f.rewind
   @f.close
-  File.chmod(0777, @f)
+  File.chmod(0o777, @f)
   @res = `clamdscan #{@f.path}`
   @f.unlink
 end

--- a/test/integration/default/cucumber/step_definitions/clamav_steps.rb
+++ b/test/integration/default/cucumber/step_definitions/clamav_steps.rb
@@ -16,7 +16,7 @@ When(/^I manually scan a (\w+) file$/) do |file_type|
   end
   @f.rewind
   @f.close
-  File.chmod(0777, @f)
+  File.chmod(0o777, @f)
   @res = `clamscan #{@f.path}`
   @f.unlink
 end


### PR DESCRIPTION
@RoboticCheese 
The locked down dependencies were killing our ability to upgrade other cookbooks.
I see you are in the middle of a major overhaul, so I wanted to propose this option for an intermediate 1.3.1 code change that would free up the 3 year old cookbook locks in metadata.rb (which, at the time, were probably essential given the relatively unstable nature of many core cookbooks back then)

I followed the PR instructions and managed to get all rubocop, food critic, and rspec tests passing when running `rake`, so I hope you find this advantageous in that respect, too--though it required many more lines be changed than I would have liked. But, that is an excellent test suite, I have to say.

I am not sure what the diff to master will look like, but here is what the diff to v1.3.0 should look like:
https://github.com/RoboticCheese/clamav-chef/compare/v1.3.0...novu:dev/v1.3.1

Would you consider forking your master branch into a develop branch and replacing master with a current working version, such as this? We (and probably many others) would rather continue to rely on your cookbook than our own version, and such a rebranching to promote a 1.3.1 release would let us do that.

I am looking forward to any feedback. Thank you for your time.

--Kevin
----
### Visual Diff from v1.3.0
https://github.com/RoboticCheese/clamav-chef/compare/v1.3.0...novu:dev/v1.3.1