### PR TITLE
fix: < 12.6 chef compatibility

### DIFF
--- a/libraries/helpers_defaults.rb
+++ b/libraries/helpers_defaults.rb
@@ -35,6 +35,8 @@ module ClamavCookbook
         case node['platform_family']
         when 'debian'
           'clamav-daemon'
+        when 'rhel'
+          'clamd'
         end
       end
 
@@ -47,6 +49,8 @@ module ClamavCookbook
         case node['platform_family']
         when 'debian'
           'clamav-freshclam'
+        when 'rhel'
+          'freshclam'
         end
       end
 
@@ -77,6 +81,8 @@ module ClamavCookbook
         case node['platform_family']
         when 'debian'
           '/var/lib/clamav'
+        when 'rhel'
+          '/var/lib/clamav'
         end
       end
 
@@ -88,6 +94,8 @@ module ClamavCookbook
       def clamav_conf_dir
         case node['platform_family']
         when 'debian'
+          '/etc/clamav'
+        when 'rhel'
           '/etc/clamav'
         end
       end
@@ -101,6 +109,8 @@ module ClamavCookbook
         case node['platform_family']
         when 'debian'
           'clamav'
+        when 'rhel'
+          'clamav'
         end
       end
 
@@ -112,6 +122,8 @@ module ClamavCookbook
       def clamav_group
         case node['platform_family']
         when 'debian'
+          'clamav'
+        when 'rhel'
           'clamav'
         end
       end
@@ -125,6 +137,12 @@ module ClamavCookbook
         case node['platform_family']
         when 'debian'
           %w(clamav clamav-daemon clamav-freshclam)
+        when 'rhel'
+          if node['platform_version'].to_i >= 7
+            %w(clamav-server clamav clamav-update)
+          else
+            %w(clamav clamav-db clamd)
+          end
         end
       end
 
@@ -137,6 +155,8 @@ module ClamavCookbook
         case node['platform_family']
         when 'debian'
           %w(libclamav-dev)
+        when 'rhel'
+          %w(clamav-devel)
         end
       end
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ license 'Apache v2.0'
 description 'Installs/configures ClamAV'
 long_description 'Installs/configures ClamAV'
 version '1.3.1'
-chef_version '>= 12'
+chef_version '>= 12' if respond_to?(:chef_version)
 
 source_url 'https://github.com/roboticcheese/clamav-chef'
 issues_url 'https://github.com/roboticcheese/clamav-chef/issues'


### PR DESCRIPTION
This allows Chef clients < 12.6 to use this cookbook. See:

* berkshelf/berkshelf#1499
* https://docs.chef.io/release_notes.html#what-s-new-in-12-6