### PR TITLE
fix "warning: constant ::Fixnum is deprecated"

### DIFF
--- a/libraries/resource_clamav_cron.rb
+++ b/libraries/resource_clamav_cron.rb
@@ -35,7 +35,7 @@ class Chef
       # Properties for the underlying cron job definition.
       #
       %i(minute hour day month weekday).each do |p|
-        property p, [Fixnum, String], required: true
+        property p, [Integer, String], required: true
       end
 
       #


### PR DESCRIPTION
Hi @RoboticCheese 

I see you have this fix as part of #92 but that PR seems to have stalled.

Would you be open to cutting some `1.3.x` releases with fixes like this and if not, is landing #92 on the horizon? Cheers